### PR TITLE
Use Enumerable Properties in Fields object

### DIFF
--- a/src/data/table/Row.js
+++ b/src/data/table/Row.js
@@ -57,6 +57,7 @@ export class Row {
             this.mAccessors.push(accessor);
 
             Object.defineProperty(this.mFields, column.name, {
+                enumerable: true,
                 get: accessor.getter,
                 set: accessor.setter,
             });


### PR DESCRIPTION
This will allow clients to use object.assign from kruda objects. `Object.assign` will only work with enumerable props.